### PR TITLE
PHP 5 backwards compatibility

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -225,6 +225,7 @@ class Api
      */
     protected function isRunningGuzzle5()
     {
-        return ($this->client::VERSION[0] == "5");
+        $client = get_class($this->client);
+        return ($client::VERSION[0] == "5");
     }
 }


### PR DESCRIPTION
`return ($this->client::VERSION[0] == "5");` doesn't work on PHP 5.6. It triggers the `syntax error, unexpected '::' (T_PAAMAYIM_NEKUDOTAYIM)` error.