### PR TITLE
Example of fixing Log class ambiguity in Email.php

### DIFF
--- a/src/Witness/Email.php
+++ b/src/Witness/Email.php
@@ -3,9 +3,9 @@
 namespace Eyewitness\Eye\Witness;
 
 use Eyewitness\Eye\Mail\PingEyewitness;
+use Illuminate\Support\Facades\Log as LogFacade;
 use Illuminate\Support\Facades\Mail;
 use Exception;
-use Log;
 
 class Email
 {
@@ -23,7 +23,7 @@ class Email
                 $this->sendImmediateMail();
             }
         } catch (Exception $e) {
-            Log::error('Unable to send Eyewitness.io email: '.$e->getMessage());
+            LogFacade::error('Unable to send Eyewitness.io email: '.$e->getMessage());
         }
     }
 


### PR DESCRIPTION
I have had an issue when calling api/eyewitness/v1/server. Issue dependent on php configuration and likely similar to :
https://bugs.php.net/bug.php?id=66773

There is an ambiguity as to which Log class to use : 
![screen shot 2017-07-12 at 3 01 49 pm](https://user-images.githubusercontent.com/3245032/28107199-4e37cce4-6719-11e7-89e7-88f7f4ca1f54.png)

While my development environment looks OK : 
PHP 7.0.1-1+deb.sury.org~trusty+2 (cli) ( NTS )
Copyright (c) 1997-2015 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2015 Zend Technologies
    with Xdebug v2.5.5, Copyright (c) 2002-2017, by Derick Rethans
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2015, by Zend Technologies

The environment on which it gets deployed has the result previously mentioned : 
"Cannot use Log as Log because the name is already in use".

Environment :
PHP 5.6.30 (cli) (built: Mar  8 2017 00:17:28) 
Copyright (c) 1997-2016 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies

My proposed change is to make more explicit which Log class to use. My request is just a proposed solution, others like renaming the Witness Log class, explictely using the illuminate class Illuminate\Support\Facades\Log::error('Unable to send Eyewitness.io email: '.$e->getMessage()); , ... may also be good.