### PR TITLE
Fix debug mode display

### DIFF
--- a/resources/views/dashboard/tabs/overview.blade.php
+++ b/resources/views/dashboard/tabs/overview.blade.php
@@ -136,7 +136,7 @@
                                 <p class="block tracking-wide text-grey text-right mr-1">Debug mode</p>
                             </div>
                             <div class="w-1/2 inline-flex">
-                                <p class="ml-4 max-w-full font-mono rounded text-xs text-white p-1 {{ $eye->application()->find('debug') ? 'bg-green' : 'bg-red' }}">{{ $eye->application()->find('debug') ? 'Disabled' : 'Enabled' }}</p>
+                                <p class="ml-4 max-w-full font-mono rounded text-xs text-white p-1 {{ $eye->application()->find('debug') ? 'bg-red' : 'bg-green' }}">{{ $eye->application()->find('debug') ? 'Enabled' : 'Disabled' }}</p>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Currently, setting `APP_DEBUG=true` in my `.env` file results in the dashboard saying debug mode is "Disabled". Setting it to `false` makes the dashboard display "Enabled". 
Simply reversing the order here fixes it so it properly displays "Disabled" when APP_DEBUG is set to false, and "Enabled" when it is set to true.