### PR TITLE
Fix last run metadata on messages

### DIFF
--- a/app/Notifications/Messages/Scheduler/Fast.php
+++ b/app/Notifications/Messages/Scheduler/Fast.php
@@ -36,7 +36,7 @@ class Fast extends BaseMessage
         return [
             'Command' => e($this->meta['scheduler']->command),
             'Schedule' => e($this->meta['scheduler']->schedule),
-            'Last Run' => e($this->meta['scheduler']->latest_ping->created_at->diffForHumans()),
+            'Last Run' => e($this->meta['scheduler']->latest_history->created_at->diffForHumans()),
             'Your alert threshold' => e($this->meta['scheduler']->alert_run_time_greater_than).' seconds',
             'Actual cron job run time' => e(round($this->meta['time_to_run'], 1)).' seconds',
         ];

--- a/app/Notifications/Messages/Scheduler/Missed.php
+++ b/app/Notifications/Messages/Scheduler/Missed.php
@@ -35,7 +35,7 @@ class Missed extends BaseMessage
     public function meta()
     {
         try {
-            $last = e($this->meta['scheduler']->latest_ping->created_at->diffForHumans());
+            $last = e($this->meta['scheduler']->latest_history->created_at->diffForHumans());
         } catch (Exception $e) {
             $last = 'Unknown';
         }

--- a/app/Notifications/Messages/Scheduler/Overdue.php
+++ b/app/Notifications/Messages/Scheduler/Overdue.php
@@ -36,7 +36,7 @@ class Overdue extends BaseMessage
         return [
             'Command' => e($this->meta['scheduler']->command),
             'Schedule' => e($this->meta['scheduler']->schedule),
-            'Last Run' => e($this->meta['scheduler']->latest_ping->created_at->diffForHumans()),
+            'Last Run' => e($this->meta['scheduler']->latest_history->created_at->diffForHumans()),
             'Your alert threshold' => e($this->meta['scheduler']->alert_run_time_greater_than).' seconds',
         ];
     }

--- a/app/Notifications/Messages/Scheduler/Slow.php
+++ b/app/Notifications/Messages/Scheduler/Slow.php
@@ -36,7 +36,7 @@ class Slow extends BaseMessage
         return [
             'Command' => e($this->meta['scheduler']->command),
             'Schedule' => e($this->meta['scheduler']->schedule),
-            'Last Run' => e($this->meta['scheduler']->latest_ping->created_at->diffForHumans()),
+            'Last Run' => e($this->meta['scheduler']->latest_history->created_at->diffForHumans()),
             'Your alert threshold' => e($this->meta['scheduler']->alert_run_time_greater_than).' seconds',
             'Actual cron job run time' => e(round($this->meta['time_to_run'], 1)).' seconds',
         ];

--- a/tests/Notifications/Messages/NotificationTest.php
+++ b/tests/Notifications/Messages/NotificationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Eyewitness\Eye\Test\Notifications\Messages;
+
+use Eyewitness\Eye\Notifications\Messages\Scheduler\Fast;
+use Eyewitness\Eye\Notifications\Messages\Scheduler\Missed;
+use Eyewitness\Eye\Notifications\Messages\Scheduler\Overdue;
+use Eyewitness\Eye\Notifications\Messages\Scheduler\Slow;
+use Eyewitness\Eye\Repo\History\Scheduler as History;
+use Eyewitness\Eye\Repo\Scheduler;
+use Eyewitness\Eye\Test\TestCase;
+
+class NotificationTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->artisan('migrate', ['--database' => 'testbench']);
+    }
+
+    public function test_overdue_message_has_metadata()
+    {
+        factory(Scheduler::class)->create();
+        $history = factory(History::class)->create();
+
+        $message = new Overdue(['scheduler' => $history->scheduler]);
+
+        $this->assertNotEmpty($message->meta());
+    }
+
+    public function test_fast_message_has_metadata()
+    {
+        $scheduler = factory(Scheduler::class)->create();
+        $history = factory(History::class)->create();
+
+        $message = new Fast([
+            'scheduler' => $scheduler,
+            'time_to_run' => $history->time_to_run
+        ]);
+
+        $this->assertNotEmpty($message->meta());
+    }
+
+    public function test_slow_message_has_metadata()
+    {
+        $scheduler = factory(Scheduler::class)->create();
+        $history = factory(History::class)->create();
+
+        $message = new Slow([
+            'scheduler' => $scheduler,
+            'time_to_run' => $history->time_to_run
+        ]);
+
+        $this->assertNotEmpty($message->meta());
+    }
+
+    public function test_missed_message_has_metadata()
+    {
+        $scheduler = factory(Scheduler::class)->create();
+
+        $message = new Missed([
+            'scheduler' => $scheduler,
+        ]);
+
+        $this->assertNotEmpty($message->meta());
+    }
+}


### PR DESCRIPTION
# Issue

Sending an Overdue message in a notification fails, because of a 'property of non-object' exception on line 39 in Overdue.php.

# Solution

Fetch last run the same way as in `eye/resources/views/dashboard/tabs/scheduler.blade.php`.

I've added some tests that fail without the fix and succeed after the fix.