### PR TITLE
replace _ by - in file names

### DIFF
--- a/app/Scheduling/Event.php
+++ b/app/Scheduling/Event.php
@@ -154,7 +154,7 @@ class Event extends OriginalEvent
         }
 
         if ($this->outputNotBeingCaptured()) {
-            $this->output = storage_path('logs/eyewitness_cron_'.sha1($this->mutexName()).'.cron.log');
+            $this->output = storage_path('logs/eyewitness-cron-'.sha1($this->mutexName()).'.cron.log');
         }
     }
 


### PR DESCRIPTION
This character "_" cannot break if displayed in HTML. This one "-" can break.  It's an issue if the file name is displayed in HTML via a Log Viewer.

See: https://github.com/rap2hpoutre/laravel-log-viewer/pull/136