### PR TITLE
Format the meta content for Slack attachments

### DIFF
--- a/app/Notifications/Drivers/Slack.php
+++ b/app/Notifications/Drivers/Slack.php
@@ -27,7 +27,7 @@ class Slack implements DriverInterface
 
         $body = [
             'text' => $message->title(),
-            'icon_url' => 'https://eyewitness.io/img/logo/icon_192_192.png',
+            'icon_url' => config('logging.channels.slack.emoji_' . ($message->isError() ? 'danger' : 'good') , '/static/emoji/1f441.png'),
             'username' => 'Eyewitness.io | '.config('app.name', 'Your Application'),
             'attachments' => [[
                 'text' => $message->markupDescription(),

--- a/app/Notifications/Drivers/Slack.php
+++ b/app/Notifications/Drivers/Slack.php
@@ -46,6 +46,12 @@ class Slack implements DriverInterface
         }
     }
     
+    /**
+     * Format the meta content for Slack attachments
+     * 
+     * @param  array  $meta  Notification meta content
+     * @return array
+     */
     protected function parseMeta($meta)
     {
         $fields = [];

--- a/app/Notifications/Drivers/Slack.php
+++ b/app/Notifications/Drivers/Slack.php
@@ -32,7 +32,7 @@ class Slack implements DriverInterface
             'attachments' => [[
                 'text' => $message->markupDescription(),
                 'color' => $message->isError() ? 'danger' : 'good',
-                'fields' => $message->meta()
+                'fields' => $this->parseMeta($message->meta())
             ]]
         ];
 
@@ -44,6 +44,19 @@ class Slack implements DriverInterface
         } catch (Exception $e) {
             app(Eye::class)->logger()->error('Unable to send Slack notification', $e);
         }
+    }
+    
+    protected function parseMeta($meta)
+    {
+        $fields = [];
+        foreach ($meta as $key => $value)
+        {
+            $fields[] = [
+                'title' => $key,
+                'value' => $value,
+            ];
+        }
+        return $fields;
     }
 
 }

--- a/app/Notifications/Messages/TestMessage.php
+++ b/app/Notifications/Messages/TestMessage.php
@@ -35,6 +35,18 @@ class TestMessage extends BaseMessage
     {
         return 'This is a manually generated notification to check your channel is working correctly.';
     }
+    
+    /**
+     * Any meta information for the message.
+     *
+     * @return array
+     */
+    public function meta()
+    {
+        return [
+            'Meta' => 'is also working',
+        ];
+    }
 
     /**
      * The notification typee.

--- a/app/Notifications/Messages/TestMessage.php
+++ b/app/Notifications/Messages/TestMessage.php
@@ -44,7 +44,7 @@ class TestMessage extends BaseMessage
     public function meta()
     {
         return [
-            'Meta' => 'is also working',
+            'Meta' => 'Meta content is also working corectly.',
         ];
     }
 


### PR DESCRIPTION
**Issues:**
1. The meta content of the message is not displayed in slack
2. When using [mattermost webhooks](https://docs.mattermost.com/developer/webhooks-incoming.html#slack-compatibility) (which are slack compatible), the notifications with meta content are not displayed at all. In the log file, there is an error like this: `IncomingWebhookRequestFromJson code=400 rid=96ru53wc3bg1tytkzs9uiwozfa uid= ip=**** Unable to parse incoming data [details: json: cannot unmarshal string into Go struct field SlackAttachment.fields of type []*model.SlackAttachmentField]`

**Cause:**
the `attachments.fields` is not in the right format. it should be an array of objects with properties `title` and `value` (as documented [here](https://api.slack.com/docs/message-attachments#attachment_structure))

**Solution:**
use a function to translate the meta object in the right format
for easier testing, I also added a meta field to the `TestMessage`