### PR TITLE
Format the meta content for Slack attachments

### DIFF
--- a/app/Notifications/Drivers/Slack.php
+++ b/app/Notifications/Drivers/Slack.php
@@ -46,23 +46,23 @@ class Slack implements DriverInterface
         }
     }
 
-       
     /**
-     * Format the meta content for Slack attachments
+     * Format the meta content for Slack attachments.
      * 
-     * @param  array  $meta  Notification meta content
+     * @param  array  $meta
      * @return array
      */
     protected function parseMeta($meta)
     {
         $fields = [];
-        foreach ($meta as $key => $value)
-        {
+        
+        foreach ($meta as $key => $value) {
             $fields[] = [
                 'title' => $key,
                 'value' => $value,
             ];
         }
+        
         return $fields;
     }
 }

--- a/app/Notifications/Drivers/Slack.php
+++ b/app/Notifications/Drivers/Slack.php
@@ -46,4 +46,23 @@ class Slack implements DriverInterface
         }
     }
 
+       
+    /**
+     * Format the meta content for Slack attachments
+     * 
+     * @param  array  $meta  Notification meta content
+     * @return array
+     */
+    protected function parseMeta($meta)
+    {
+        $fields = [];
+        foreach ($meta as $key => $value)
+        {
+            $fields[] = [
+                'title' => $key,
+                'value' => $value,
+            ];
+        }
+        return $fields;
+    }
 }

--- a/app/Notifications/Drivers/Slack.php
+++ b/app/Notifications/Drivers/Slack.php
@@ -32,7 +32,7 @@ class Slack implements DriverInterface
             'attachments' => [[
                 'text' => $message->markupDescription(),
                 'color' => $message->isError() ? 'danger' : 'good',
-                'fields' => $message->meta()
+                'fields' => $this->parseMeta($message->meta())
             ]]
         ];
 


### PR DESCRIPTION
**Issues:**
1. The meta content of the message is not displayed in slack
2. When using [mattermost webhooks](https://docs.mattermost.com/developer/webhooks-incoming.html#slack-compatibility) (which are slack compatible), the notifications with meta content are not displayed at all. In the log file, there is an error like this: `IncomingWebhookRequestFromJson code=400 rid=96ru53wc3bg1tytkzs9uiwozfa uid= ip=**** Unable to parse incoming data [details: json: cannot unmarshal string into Go struct field SlackAttachment.fields of type []*model.SlackAttachmentField]`

**Cause:**
the `attachments.fields` is not in the right format. it should be an array of objects with properties `title` and `value` (as documented [here](https://api.slack.com/docs/message-attachments#attachment_structure))

**Solution:**
use a function to translate the meta object in the right format