### PR TITLE
bugfix - #47 - change results_url

### DIFF
--- a/app/Monitors/Ssl.php
+++ b/app/Monitors/Ssl.php
@@ -154,7 +154,7 @@ class Ssl extends BaseMonitor
     protected function saveSslRecord($domain, $result)
     {
         $record['grade'] = $result['results']['grade'];
-        $record['results_url'] = $result['internals']['alternate_url'];
+        $record['results_url'] = 'https://www.htbridge.com/ssl/?id=' . $result['internals']['short_id'];
 
         if (isset($result['certificates']['information'][0])) {
             $record['valid'] = $result['certificates']['information'][0]['valid_now'];


### PR DESCRIPTION
It seems the 'result_url' is no longer available in the response as ‘alternate_url’. Now we combine the ‘short_id’ with a base url to get the alternate_url.