### PR TITLE
correctly cast notification's created_at to a datetime instead of just date

### DIFF
--- a/app/Repo/Notifications/History.php
+++ b/app/Repo/Notifications/History.php
@@ -27,6 +27,6 @@ class History extends Model
      */
     protected $casts = [
         'meta' => 'array',
-        'created_at' => 'date'
+        'created_at' => 'datetime'
     ];
 }


### PR DESCRIPTION
This fixes notifications displaying the incorrect "Created" time:

```
2018-10-03 00:00:00 (10 hours ago)
```

It should be more like this:
```
2018-10-03 11:05:33 (15 minutes ago)
```