### PR TITLE
Update composer lock check url from sensiolabs to symfony security.

### DIFF
--- a/src/App/Api/Api.php
+++ b/src/App/Api/Api.php
@@ -191,7 +191,7 @@ class Api
     }
 
     /**
-     * Run a check for the composer lock against the SensioLabs API.
+     * Run a check for the composer lock against the Symfony Security API.
      *
      * @return json
      */
@@ -205,10 +205,10 @@ class Api
             } else {
                 $this->headers['multipart'] = [['name' => 'lock', 'contents' => fopen(config('eyewitness.composer_lock_file_location'), 'r')]];
             }
-            $response = $this->client->post('https://security.sensiolabs.org/check_lock', $this->headers);
+            $response = $this->client->post('https://security.symfony.com/check_lock', $this->headers);
             return json_decode($response->getBody()->getContents(), true);
         } catch (Exception $e) {
-            LogFacade::error('SensioLabs Composer Lock check failed due to: '.$e->getMessage());
+            LogFacade::error('Symfony Security Composer Lock check failed due to: '.$e->getMessage());
         }
 
         return null;

--- a/src/config/eyewitness.php
+++ b/src/config/eyewitness.php
@@ -131,8 +131,8 @@ return [
      |--------------------------------------------------------------------------
      |
      | If you have enabled 'monitor_composer_lock' - then a daily check of
-     | your composer.lock file will occur against the SensioLabs Security
-     | check at https://security.sensiolabs.org/
+     | your composer.lock file will occur against the Symfony Security
+     | check at https://security.symfony.com/
      |
      | The below is the location of your composer.lock file. You only need to
      | modify this config if your lock file is in a different location than


### PR DESCRIPTION
The composer lock file check url has moved from SensioLabs (https://security.sensiolabs.org) to Symfony (https://security.symfony.com), [as mentioned here](https://github.com/sensiolabs/security-checker/issues/149#issuecomment-467438649).

This PR updates the url and comments to reflect this change.

